### PR TITLE
Removed the reference to the removed test subdirectory in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,18 +53,6 @@ add_dependencies(MrsUavGazeboTesting_TestGeneric
   )
 
 ## --------------------------------------------------------------
-## |                           Testing                          |
-## --------------------------------------------------------------
-
-if(CATKIN_ENABLE_TESTING AND MRS_ENABLE_TESTING)
-
-  message(WARNING "Testing enabled.")
-
-  add_subdirectory(test)
-
-endif()
-
-## --------------------------------------------------------------
 ## |                           Install                          |
 ## --------------------------------------------------------------
 


### PR DESCRIPTION
See title. The compilation was complaining that the `test` directory doesn't contain a `CMakeLists.txt` file.
![image](https://github.com/ctu-mrs/mrs_uav_gazebo_testing/assets/21334530/6599c03a-ca3c-4133-97b0-a0677dca7c6f)
